### PR TITLE
Feature/slider widget

### DIFF
--- a/client/src/components/common/spacing/FullSize.js
+++ b/client/src/components/common/spacing/FullSize.js
@@ -4,6 +4,7 @@ const FullSize = styled.div`
   position: relative;
   width: 100%;
   height: 100%;
+  overflow: hidden;
 `;
 
 export default FullSize;

--- a/client/src/components/common/spacing/FullSize.js
+++ b/client/src/components/common/spacing/FullSize.js
@@ -1,0 +1,9 @@
+import styled from "styled-components";
+
+const FullSize = styled.div`
+  position: relative;
+  width: 100%;
+  height: 100%;
+`;
+
+export default FullSize;

--- a/client/src/components/common/spacing/Overlay.js
+++ b/client/src/components/common/spacing/Overlay.js
@@ -1,0 +1,40 @@
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+
+const DEFAULT_PROPS = {
+  Z_INDEX: 2
+};
+
+const interpretHorizontalPosition = (position) => {
+  console.log("interpretting horizontal position", position);
+  return position === 'end'
+    ? 'flex-end'
+    : 'flex-start';
+};
+
+const interpretVerticalPosition = (position) =>
+  position === 'bottom'
+    ? 'column-reverse'
+    : 'column';
+
+const Overlay = styled.div`
+  display: flex;
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  top: 0;
+  left: 0;
+  ${(props) => `
+    flex-direction: ${interpretVerticalPosition(props.verticalPosition)};
+    align-items: ${interpretHorizontalPosition(props.horizontalPosition)};
+    z-index: ${props.zIndex || DEFAULT_PROPS.Z_INDEX};
+  `}
+`;
+
+Overlay.propTypes = {
+  horizontalPosition: PropTypes.oneOf(['start', 'end']),
+  verticalPosition: PropTypes.oneOf(['top', 'bottom'])
+};
+
+export default Overlay;

--- a/client/src/components/common/spacing/Overlay.js
+++ b/client/src/components/common/spacing/Overlay.js
@@ -5,12 +5,10 @@ const DEFAULT_PROPS = {
   Z_INDEX: 2
 };
 
-const interpretHorizontalPosition = (position) => {
-  console.log("interpretting horizontal position", position);
-  return position === 'end'
+const interpretHorizontalPosition = (position) =>
+  position === 'end'
     ? 'flex-end'
     : 'flex-start';
-};
 
 const interpretVerticalPosition = (position) =>
   position === 'bottom'

--- a/client/src/components/common/spacing/index.js
+++ b/client/src/components/common/spacing/index.js
@@ -1,5 +1,9 @@
 import Justify from './Justify';
+import Overlay from './Overlay';
+import FullSize from './FullSize';
 
 export {
-  Justify
+  Justify,
+  Overlay,
+  FullSize
 }

--- a/client/src/components/common/typography/index.js
+++ b/client/src/components/common/typography/index.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import Title from './Title';
 import Body from './Body';
 import ExtendWithFont from './ExtendWithFont';

--- a/client/src/components/gridItems/Slide.js
+++ b/client/src/components/gridItems/Slide.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import TextTile from './TextTile';
+import styled from 'styled-components';
+import { Overlay, FullSize } from '../common/spacing';
+import SlideContent from "./SlideContent";
+
+const Slide = (props) => {
+  const {
+    title,
+    description,
+    visible,
+    content
+  } = props;
+
+  return (
+    <FullSize>
+      <Overlay
+        verticalPosition={'bottom'}
+        horizontalPosition={'end'}
+      >
+        <TextTile
+          title={title}
+          description={description}
+        />
+      </Overlay>
+      <SlideContent
+        type={content ? content.type : 'image'}
+        content={content}
+      />
+    </FullSize>
+  );
+};
+
+Slide.propTypes = {
+  label: PropTypes.string,
+  visible: PropTypes.bool,
+  content: PropTypes.oneOf([PropTypes.string, PropTypes.func, PropTypes.object])
+};
+
+export default Slide;

--- a/client/src/components/gridItems/Slide.js
+++ b/client/src/components/gridItems/Slide.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import TextTile from './TextTile';
-import styled from 'styled-components';
 import { Overlay, FullSize } from '../common/spacing';
 import SlideContent from "./SlideContent";
 
@@ -9,7 +8,6 @@ const Slide = (props) => {
   const {
     title,
     description,
-    visible,
     content
   } = props;
 

--- a/client/src/components/gridItems/SlideContent.js
+++ b/client/src/components/gridItems/SlideContent.js
@@ -3,14 +3,23 @@ import PropTypes from 'prop-types';
 import { FullSize } from '../common/spacing';
 import styled from 'styled-components';
 
+const StyledFullSizeImageCover = styled(FullSize)`
+  ${props => `
+    background: url(${props.imagePath}) no-repeat center center
+  `}
+  -webkit-background-size: cover;
+  -moz-background-size: cover;
+  -o-background-size: cover;
+  background-size: cover;
+`;
+
 const renderContent = (type, content) => {
   switch(type) {
     case 'image':
       return (
-        <FullSize
-          as={'img'}
-          src={content ? content.imagePath : ''}
-          alt={content ? content.imageLabel : ''}
+        <StyledFullSizeImageCover
+          imagePath={content ? content.imagePath : ''}
+          title={content ? content.imageLabel : ''}
         />
       );
   }

--- a/client/src/components/gridItems/SlideContent.js
+++ b/client/src/components/gridItems/SlideContent.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FullSize } from '../common/spacing';
+import styled from 'styled-components';
+
+const renderContent = (type, content) => {
+  switch(type) {
+    case 'image':
+      return (
+        <FullSize
+          as={'img'}
+          src={content ? content.imagePath : ''}
+          alt={content ? content.imageLabel : ''}
+        />
+      );
+  }
+};
+
+const SlideContent = (props) => {
+  const {type, content} = props;
+  return (
+    renderContent(type, content)
+  );
+};
+
+SlideContent.propTypes = {
+  type: PropTypes.oneOf(['image']),
+  content: PropTypes.shape({
+    imagePath: PropTypes.string,
+    imageLabel: PropTypes.string
+  })
+};
+
+export default SlideContent;

--- a/client/src/components/gridItems/SlideStepper.js
+++ b/client/src/components/gridItems/SlideStepper.js
@@ -32,7 +32,7 @@ class SlideStepper extends React.Component {
   render() {
     const {
       children,
-      autoPlay,
+      autoplay,
       interval
     } = this.props;
 
@@ -43,7 +43,7 @@ class SlideStepper extends React.Component {
     return (
       <FullSize>
         <StyledAutoPlaySwipableViews
-          autoPlay={autoPlay}
+          autoplay={autoplay}
           interval={interval}
           index={slideIndex}
           onChangeIndex={this.handleChangeSlide}
@@ -59,7 +59,7 @@ SlideStepper.propTypes = {
   children: PropTypes.arrayOf(
     PropTypes.instanceOf(Slide)),
   interval: PropTypes.number,
-  autoPlay: PropTypes.bool,
+  autoplay: PropTypes.bool,
 };
 
 export default SlideStepper;

--- a/client/src/components/gridItems/SlideStepper.js
+++ b/client/src/components/gridItems/SlideStepper.js
@@ -16,16 +16,6 @@ const StyledAutoPlaySwipableViews = styled(AutoPlaySwipableViews)`
   > div {
     height: 100%;
     width: 100%;
-    
-    > div {
-      height: 100%;
-      width: 100%;
-      
-      > div {
-        height: 100%;
-        width: 100%;
-      }
-    }
   }
 `;
 

--- a/client/src/components/gridItems/SlideStepper.js
+++ b/client/src/components/gridItems/SlideStepper.js
@@ -1,0 +1,75 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import SwipableViews from 'react-swipeable-views';
+import { autoPlay } from 'react-swipeable-views-utils';
+import styled from 'styled-components';
+import Slide from './Slide';
+import FullSize from "../common/spacing/FullSize";
+
+const AutoPlaySwipableViews = autoPlay(SwipableViews);
+
+const StyledAutoPlaySwipableViews = styled(AutoPlaySwipableViews)`
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  
+  > div {
+    height: 100%;
+    width: 100%;
+    
+    > div {
+      height: 100%;
+      width: 100%;
+      
+      > div {
+        height: 100%;
+        width: 100%;
+      }
+    }
+  }
+`;
+
+class SlideStepper extends React.Component {
+
+  state = {
+    slideIndex: 0
+  };
+
+  handleChangeSlide = (index) => {
+    this.setState({slideIndex: index});
+  };
+
+  render() {
+    const {
+      children,
+      autoPlay,
+      interval
+    } = this.props;
+
+    const {
+      slideIndex
+    } = this.state;
+
+    return (
+      <FullSize>
+        <StyledAutoPlaySwipableViews
+          autoPlay={autoPlay}
+          interval={interval}
+          index={slideIndex}
+          onChangeIndex={this.handleChangeSlide}
+        >
+          {children}
+        </StyledAutoPlaySwipableViews>
+      </FullSize>
+    );
+  };
+}
+
+SlideStepper.propTypes = {
+  children: PropTypes.arrayOf(
+    PropTypes.instanceOf(Slide)),
+  interval: PropTypes.number,
+  autoPlay: PropTypes.bool,
+};
+
+export default SlideStepper;

--- a/client/src/components/gridItems/TextTile.js
+++ b/client/src/components/gridItems/TextTile.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import {
+  Body,
+  Title
+} from '../common/typography';
+
+const StyledContainer = styled.div`
+  background-color: rgba(255, 255, 255, 0.4);
+  padding: 3%;
+`;
+
+const TextTile = (props) => {
+  const {
+    title,
+    description
+  } = props;
+  return (
+    <StyledContainer>
+      <Title>{title}</Title>
+      <Body>{description}</Body>
+    </StyledContainer>
+  )
+};
+
+TextTile.propTypes = {
+  label: PropTypes.string,
+  description: PropTypes.string
+};
+
+export default TextTile;

--- a/client/src/components/gridItems/componentFactory.js
+++ b/client/src/components/gridItems/componentFactory.js
@@ -50,21 +50,21 @@ const createElement = (element, handleRemove) => {
             >
               <Slide
                 title={'Dem first slide'}
+                description={'A nice description, indeed.'}
                 content={{
                   type: 'image',
                   imagePath: 'https://picsum.photos/200/300/?random',
                   imageLabel: 'Dis be image',
                 }}
-                description={'A nice description, indeed.'}
               />
               <Slide
                 title={'Dis be second one'}
+                description={'Something to be reading?'}
                 content={{
                   type: 'image',
-                  imagePath: 'https://picsum.photos/200/300/?random',
+                  imagePath: 'https://picsum.photos/400/300/?random',
                   imageLabel: 'Dis be image',
                 }}
-                description={'Something to be reading?'}
               />
             </SlideStepper>;
           default:

--- a/client/src/components/gridItems/componentFactory.js
+++ b/client/src/components/gridItems/componentFactory.js
@@ -14,7 +14,8 @@ const createElement = (element, handleRemove) => {
     position: "absolute",
     right: 10,
     top: 5,
-    cursor: "pointer"
+    cursor: "pointer",
+    zIndex: 100
   };
   const index = element.i;
   const widget = element.widget;
@@ -71,6 +72,7 @@ const createElement = (element, handleRemove) => {
             return <div className="textWidget">{widget}</div>;
         }
       })()}
+      {/* @ToDo create new component for remove button */}
       <span
         className="remove"
         style={removeStyle}

--- a/client/src/components/gridItems/componentFactory.js
+++ b/client/src/components/gridItems/componentFactory.js
@@ -6,6 +6,7 @@ import React from "react";
 import Clock from "./Clock";
 import Weather from "./Weather";
 import ApplicationShortCut from './ApplicationShortCut';
+import SlideStepper from './SlideStepper';
 import Slide from "./Slide";
 
 const createElement = (element, handleRemove) => {
@@ -43,6 +44,29 @@ const createElement = (element, handleRemove) => {
               }}
               description={'Ze slide of slides'}
             />;
+          case "SlideStepper":
+            return <SlideStepper
+              autoplay
+            >
+              <Slide
+                title={'Dem first slide'}
+                content={{
+                  type: 'image',
+                  imagePath: 'https://picsum.photos/200/300/?random',
+                  imageLabel: 'Dis be image',
+                }}
+                description={'A nice description, indeed.'}
+              />
+              <Slide
+                title={'Dis be second one'}
+                content={{
+                  type: 'image',
+                  imagePath: 'https://picsum.photos/200/300/?random',
+                  imageLabel: 'Dis be image',
+                }}
+                description={'Something to be reading?'}
+              />
+            </SlideStepper>;
           default:
             return <div className="textWidget">{widget}</div>;
         }

--- a/client/src/components/gridItems/componentFactory.js
+++ b/client/src/components/gridItems/componentFactory.js
@@ -6,6 +6,7 @@ import React from "react";
 import Clock from "./Clock";
 import Weather from "./Weather";
 import ApplicationShortCut from './ApplicationShortCut';
+import Slide from "./Slide";
 
 const createElement = (element, handleRemove) => {
   const removeStyle = {
@@ -31,6 +32,16 @@ const createElement = (element, handleRemove) => {
             return <ApplicationShortCut
               title={'Invision'}
               onClick={() => window.location = 'https://invisionapp.com'}
+            />;
+          case "Slide":
+            return <Slide
+              title={'Ze slide of slides'}
+              content={{
+                type: 'image',
+                imagePath: 'https://picsum.photos/200/300/?random',
+                imageLabel: 'Dis be image',
+              }}
+              description={'Ze slide of slides'}
             />;
           default:
             return <div className="textWidget">{widget}</div>;

--- a/client/src/components/gridItems/constants.js
+++ b/client/src/components/gridItems/constants.js
@@ -3,7 +3,8 @@ const WIDGET_TYPES = [
   'Clock',
   'Photo',
   'Weather',
-  'ApplicationShortCut'
+  'ApplicationShortCut',
+  'Slide'
 ];
 
 const WIDGET_LABELS = [
@@ -12,6 +13,7 @@ const WIDGET_LABELS = [
   'Photo',
   'Weather',
   'Application shortcut',
+  'Slide'
 ];
 
 const WIDGET_TYPES_AS_VALUES_WITH_LABELS = WIDGET_TYPES.map((widgetType, index) =>

--- a/client/src/components/gridItems/constants.js
+++ b/client/src/components/gridItems/constants.js
@@ -4,7 +4,8 @@ const WIDGET_TYPES = [
   'Photo',
   'Weather',
   'ApplicationShortCut',
-  'Slide'
+  'Slide',
+  'SlideStepper'
 ];
 
 const WIDGET_LABELS = [
@@ -13,7 +14,8 @@ const WIDGET_LABELS = [
   'Photo',
   'Weather',
   'Application shortcut',
-  'Slide'
+  'Slide',
+  'Slide Show'
 ];
 
 const WIDGET_TYPES_AS_VALUES_WITH_LABELS = WIDGET_TYPES.map((widgetType, index) =>

--- a/client/src/scss/components/dashboardEdit/_dashboardEdit.scss
+++ b/client/src/scss/components/dashboardEdit/_dashboardEdit.scss
@@ -62,6 +62,7 @@
         bottom: 0;
         right: 0;
         cursor: se-resize;
+        z-index: 100;
       }
 
       .react-grid-item > .react-resizable-handle::after {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "react-dom": "^16.8.1",
     "react-scripts": "^2.1.1",
     "react-swipeable-views": "^0.13.1",
+    "react-swipeable-views-utils": "^0.13.1",
     "styled-components": "^4.1.3",
     "validator": "^10.11.0"
   },

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "react": "^16.8.1",
     "react-dom": "^16.8.1",
     "react-scripts": "^2.1.1",
+    "react-swipeable-views": "^0.13.1",
     "styled-components": "^4.1.3",
     "validator": "^10.11.0"
   },


### PR DESCRIPTION
Added components to allow for the creation of slides in a slideshow. The `SlideStepper` steps to various `Slide` components at a given interval.

Each `Slide` of the type `image` can be given a specific `imagePath` to load as a background. Using the title and the description, a small information box can be added to a slide.

The graphical representation of this all needs some work, but functionally it works :).

Example on how to use it:
```
<SlideStepper
  autoplay
  interval={6000}
>
  <Slide
    title={'Dem first slide'}
    content={{
      type: 'image',
      imagePath: 'https://picsum.photos/200/300/?random',
      imageLabel: 'Dis be image',
    }}
    description={'A nice description, indeed.'}
  />
  <Slide
    title={'Dis be second one'}
    description={'Something to be reading?'}
    content={{
      type: 'image',
      imagePath: 'https://picsum.photos/200/300/?random',
      imageLabel: 'Dis be image',
    }}
  />
</SlideStepper>
```