### PR TITLE
Do not use --prefix for client installiation

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "server": "nodemon server.js",
     "client": "npm start --prefix client",
     "install-server": "npm install",
-    "install-client": "npm install --prefix client",
+    "install-client": "cd client && npm install",
     "install-all": "npm run install-server && npm run install-client",
     "dev": "concurrently \"npm run server\" \"npm run client\"",
     "heroku-postbuild": "NPM_CONFIG_PRODUCTION=false npm install --prefix client && npm run heroku-build --prefix client"


### PR DESCRIPTION
This causes npm to do strange things with the installation path (on windows atleast).